### PR TITLE
Incorporate amount into weight calc onload

### DIFF
--- a/src/utility.js
+++ b/src/utility.js
@@ -24,7 +24,7 @@ export const calculatePackWeight = (allShelfItems) => {
     if(Object.keys(shelfItems).length) {
       const items = Object.values(shelfItems)
         items.forEach(item => {
-          total += Number(item.weight);
+          total += Number(item.weight * item.amount);
       });
     }
     return total


### PR DESCRIPTION
## What does this PR do (summary of changes)?
- This fixes a small bug
- On load, the weight calculations was only using the weight and not the amount
- the utility function was changed to incorporate amount
## How should it be tested?
- add an item with more than 1 amount
- refresh the page, and the amount should reflect the added item and amount
## Future Iterations:
N/A
