### PR TITLE
Feature/weight per shelf category

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -16,7 +16,6 @@ class App extends Component {
   }
 
   render() {
-    console.log("test app")
   return (
     <div className="App">
       <Route exact path="/">

--- a/src/components/PackStatistics/PackStatistics.js
+++ b/src/components/PackStatistics/PackStatistics.js
@@ -1,10 +1,15 @@
 import  React from "react";
 import  backpackerImg  from "../../assets/pinpng.com-mountain-icon-png-169757.png";
-// import { calcShelfWeights } from "../../utility";
 
-const PackStatistics = ({ packWeight, packItems, shelves }) => {
+
+const PackStatistics = ({ packWeight, shelves }) => {
   const packWeightLbs = (packWeight/ 16).toFixed(2)
-  // const shelfWeights = calcShelfWeights(packItems, shelves)
+  const shelfWeights = shelves.map(shelf => {
+    const shelfWeightInfo = Object.entries(shelf)
+    return (
+      <li>{shelfWeightInfo[0]}: {shelfWeightInfo[1]}</li>
+    )
+  })
   return (
     <aside className="statistics">
       <h1 className="statistics-title">Base Weight</h1>
@@ -17,7 +22,7 @@ const PackStatistics = ({ packWeight, packItems, shelves }) => {
           <img className="statistics-backpacker-img"  src={backpackerImg} alt="backpacker climbing silhouette"/>
         </div>
         <ul className="statistics-category-totals">
-          <li></li>
+          {shelfWeights}
         </ul>
       </article>
     </aside>

--- a/src/components/PackStatistics/PackStatistics.js
+++ b/src/components/PackStatistics/PackStatistics.js
@@ -1,15 +1,10 @@
 import  React from "react";
+import ShelfStatistics from "../ShelfStatistics/ShelfStatistics";
 import  backpackerImg  from "../../assets/pinpng.com-mountain-icon-png-169757.png";
 
 
 const PackStatistics = ({ packWeight, shelves }) => {
   const packWeightLbs = (packWeight/ 16).toFixed(2)
-  const shelfWeights = shelves.map((shelf, i) => {
-    const shelfWeightInfo = Object.entries(shelf)
-    return (
-      <li key={i}>{shelfWeightInfo[0]}: {shelfWeightInfo[1]}</li>
-    )
-  })
   return (
     <aside className="statistics">
       <h1 className="statistics-title">Base Weight</h1>
@@ -21,9 +16,7 @@ const PackStatistics = ({ packWeight, shelves }) => {
           </ul>
           <img className="statistics-backpacker-img"  src={backpackerImg} alt="backpacker climbing silhouette"/>
         </div>
-        <ul className="statistics-category-totals">
-          {shelfWeights}
-        </ul>
+        <ShelfStatistics shelves={shelves}/>
       </article>
     </aside>
   )

--- a/src/components/PackStatistics/PackStatistics.js
+++ b/src/components/PackStatistics/PackStatistics.js
@@ -1,8 +1,10 @@
-import { React, Component } from "react";
+import  React from "react";
 import  backpackerImg  from "../../assets/pinpng.com-mountain-icon-png-169757.png";
+import { calcShelfWeights } from "../../utility";
 
-const PackStatistics = ({ packWeight }) => {
+const PackStatistics = ({ packWeight, packItems, shelves }) => {
   const packWeightLbs = (packWeight/ 16).toFixed(2)
+  const shelfWeights = calcShelfWeights(packItems, shelves)
   return (
     <aside className="statistics">
       <h1 className="statistics-title">Base Weight</h1>
@@ -15,7 +17,7 @@ const PackStatistics = ({ packWeight }) => {
           <img className="statistics-backpacker-img"  src={backpackerImg} alt="backpacker climbing silhouette"/>
         </div>
         <ul className="statistics-category-totals">
-          <p>Category breakdown will go here</p>
+          <li></li>
         </ul>
       </article>
     </aside>

--- a/src/components/PackStatistics/PackStatistics.js
+++ b/src/components/PackStatistics/PackStatistics.js
@@ -1,10 +1,10 @@
 import  React from "react";
 import  backpackerImg  from "../../assets/pinpng.com-mountain-icon-png-169757.png";
-import { calcShelfWeights } from "../../utility";
+// import { calcShelfWeights } from "../../utility";
 
 const PackStatistics = ({ packWeight, packItems, shelves }) => {
   const packWeightLbs = (packWeight/ 16).toFixed(2)
-  const shelfWeights = calcShelfWeights(packItems, shelves)
+  // const shelfWeights = calcShelfWeights(packItems, shelves)
   return (
     <aside className="statistics">
       <h1 className="statistics-title">Base Weight</h1>

--- a/src/components/PackStatistics/PackStatistics.js
+++ b/src/components/PackStatistics/PackStatistics.js
@@ -4,6 +4,7 @@ import  backpackerImg  from "../../assets/pinpng.com-mountain-icon-png-169757.pn
 
 
 const PackStatistics = ({ packWeight, shelves }) => {
+  const packWeightOz = packWeight.toFixed(2)
   const packWeightLbs = (packWeight/ 16).toFixed(2)
   return (
     <aside className="statistics">
@@ -11,7 +12,7 @@ const PackStatistics = ({ packWeight, shelves }) => {
       <article className="statistics-container">
         <div className="statistics-totals-container">
           <ul className="statistics-totals">
-            <li><span className="total total-ozs">{packWeight} Oz</span></li>
+            <li><span className="total total-ozs">{packWeightOz} Oz</span></li>
             <li><span className="total total-lbs">{packWeightLbs} Lbs</span></li>
           </ul>
           <img className="statistics-backpacker-img"  src={backpackerImg} alt="backpacker climbing silhouette"/>

--- a/src/components/PackStatistics/PackStatistics.js
+++ b/src/components/PackStatistics/PackStatistics.js
@@ -4,10 +4,10 @@ import  backpackerImg  from "../../assets/pinpng.com-mountain-icon-png-169757.pn
 
 const PackStatistics = ({ packWeight, shelves }) => {
   const packWeightLbs = (packWeight/ 16).toFixed(2)
-  const shelfWeights = shelves.map(shelf => {
+  const shelfWeights = shelves.map((shelf, i) => {
     const shelfWeightInfo = Object.entries(shelf)
     return (
-      <li>{shelfWeightInfo[0]}: {shelfWeightInfo[1]}</li>
+      <li key={i}>{shelfWeightInfo[0]}: {shelfWeightInfo[1]}</li>
     )
   })
   return (

--- a/src/components/PackStatistics/PackStatistics.scss
+++ b/src/components/PackStatistics/PackStatistics.scss
@@ -1,7 +1,7 @@
 .statistics {
   background-color: $lime-green;
-  height: 100%;
-  width: 25%; 
+  width: 25%;
+  min-height: 100%; 
 }
 
 .statistics-title {
@@ -38,10 +38,6 @@
 
 .total-lbs {
   color: rgb(255, 89, 0);
-}
-
-.statistics-category-totals {
-  flex: 1; 
 }
 
 .statistics-backpacker-img {

--- a/src/components/ShelfCard/ShelfCard.js
+++ b/src/components/ShelfCard/ShelfCard.js
@@ -11,7 +11,7 @@ class ShelfCard extends Component {
       weight: "",
       amount: "",
       error: "",
-      expanded: "collapsed", 
+      expanded: "collapsed", // use boolean here
     }
   }
 

--- a/src/components/ShelfCard/ShelfCard.js
+++ b/src/components/ShelfCard/ShelfCard.js
@@ -48,15 +48,16 @@ class ShelfCard extends Component {
   }
 
   render() {
+    console.log(this.state.weight)
     const { shelfName, shelfItems, deleteItem } = this.props;
     return (
       <article className="shelf-card">
         <div className="shelf-category-container">
           <h2 className="shelf-category">{shelfName}</h2>
           <button 
-          className="shelf-expand-btn" 
-          aria-expanded="false"
-          onClick={this.expandShelf}
+            className="shelf-expand-btn" 
+            aria-expanded="false"
+            onClick={this.expandShelf}
           >
             <MdExpandMore className={`shelf-expand-icon ${this.state.expanded}`}/>
           </button>
@@ -66,44 +67,46 @@ class ShelfCard extends Component {
           <form className={`form-add-item ${this.state.expanded}`} onSubmit={(event) => this.handleSubmit(event, shelfName)}>
             <label className="form-item-label">gear name
             <input
-            className="form-item-input"
-            type="text"
-            name="itemName"
-            value={this.state.itemName}
-            onChange={this.handleChange}
+              className="form-item-input"
+              type="text"
+              name="itemName"
+              value={this.state.itemName}
+              onChange={this.handleChange}
             />
             </label>
             <label className="form-quantity-label"> weight
             <input
-            className="form-quantity-input"
-            type="number"
-            min="0"
-            name="weight"
-            value={this.state.weight}
-            onChange={this.handleChange}
+              className="form-quantity-input"
+              type="number"
+              min="0"
+              step="any"
+              name="weight"
+              value={this.state.weight}
+              onChange={this.handleChange}
             /> oz
             </label>
             <label className="form-quantity-label"> amount
             <input
-            className="form-quantity-input"
-            type="number"
-            min="0"
-            name="amount"
-            value={this.state.amount}
-            onChange={this.handleChange}
+              className="form-quantity-input"
+              type="number"
+              min="0"
+              step="any"
+              name="amount"
+              value={this.state.amount}
+              onChange={this.handleChange}
             /> 
             </label>
             <button
-            type="submit"
-            className="form-add-item-btn"
+              type="submit"
+              className="form-add-item-btn"
             >
               <MdAdd className="form-add-item-icon"/>
             </button>
           </form>
           <ShelfItems 
-          shelfName={shelfName}
-          shelfItems={shelfItems}
-          deleteItem={deleteItem}
+            shelfName={shelfName}
+            shelfItems={shelfItems}
+            deleteItem={deleteItem}
           />
         </div>
       </article>

--- a/src/components/ShelfStatistics/ShelfStatistics.js
+++ b/src/components/ShelfStatistics/ShelfStatistics.js
@@ -1,0 +1,17 @@
+import React from "react";
+
+const ShelfStatistics = ({ shelves }) => {
+  const shelfWeights = shelves.map((shelf, i) => {
+    const shelfWeightInfo = Object.entries(shelf)
+    return (
+      <li key={i}>{shelfWeightInfo[0]}: {shelfWeightInfo[1]}</li>
+    )
+  })
+  return (
+    <ul>
+      {shelfWeights}
+    </ul>
+  )
+}
+
+export default ShelfStatistics; 

--- a/src/components/ShelfStatistics/ShelfStatistics.js
+++ b/src/components/ShelfStatistics/ShelfStatistics.js
@@ -2,15 +2,23 @@ import React from "react";
 
 const ShelfStatistics = ({ shelves }) => {
   const shelfWeights = shelves.map((shelf, i) => {
-    const shelfWeightInfo = Object.entries(shelf)
+    const shelfWeightInfo = Object.entries(shelf).flat()
     return (
-      <li key={i}>{shelfWeightInfo[0]}: {shelfWeightInfo[1]}</li>
+      <li 
+        key={i}
+        className="statistics-category"
+      >
+          <span className="statistics-category-title">{shelfWeightInfo[0]}:</span>{shelfWeightInfo[1]} 
+      </li>
     )
   })
   return (
-    <ul>
-      {shelfWeights}
-    </ul>
+    <div className="statistics-category-container">
+      <h2>The Breakdown</h2>
+      <ul className="statistics-category-list">
+        {shelfWeights}
+      </ul>
+    </div>
   )
 }
 

--- a/src/components/ShelfStatistics/ShelfStatistics.scss
+++ b/src/components/ShelfStatistics/ShelfStatistics.scss
@@ -1,0 +1,20 @@
+.statistics-category-container {
+  flex: 1;
+  margin: 10px;   
+}
+
+.statistics-category-list {
+  list-style-type: none;
+  padding: 0;
+  margin: 0; 
+}
+
+.statistics-category {
+  font-size: 2rem;
+  padding: 10px;  
+}
+
+.statistics-category-title {
+  margin-right: 10px;
+  font-weight: 600;  
+}

--- a/src/components/Shelves/Shelves.js
+++ b/src/components/Shelves/Shelves.js
@@ -76,6 +76,7 @@ class Shelves extends Component {
     const shelves = this.state.shelves.map((shelf, i) => {
     return <ShelfCard
     key={i}
+    id={i}
     shelfName={shelf}
     shelfItems={this.state.items[shelf]}
     updateItems={this.updateItems}
@@ -88,7 +89,11 @@ class Shelves extends Component {
         <p className="shelves-intro">Here are some shelves to get you started...</p>
         {shelves}
       </section>
-      <PackStatistics packWeight={this.state.totalWeight}/>
+      <PackStatistics 
+      packWeight={this.state.totalWeight} 
+      packItems={this.state.items} 
+      shelves={this.state.shelves}
+      />
     </main>
 
   )

--- a/src/components/Shelves/Shelves.js
+++ b/src/components/Shelves/Shelves.js
@@ -1,5 +1,5 @@
 import { React, Component } from "react";
-import { getItems, getShelves, removeItem } from "../../ApiCalls";
+import { addItem, getItems, getShelves, removeItem } from "../../ApiCalls";
 import { calculatePackWeight, createItemList, getShelfItems, calcItemWeight, calcShelfWeights } from "../../utility";
 import ShelfCard from "../ShelfCard/ShelfCard";
 import PackStatistics from "../PackStatistics/PackStatistics";
@@ -30,27 +30,22 @@ class Shelves extends Component {
     })    
   }
 
-  deleteShelf = (shelfName) => {
-    fetch(`https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d/basket/${shelfName}`, {
-      method: "DELETE",
-      headers: {"Content-Type": "application/json"},
-      redirect:'follow'
-    })
-    .then(response => response.text())
-    .then(response => {
-      console.log(response)
-    })
-  }
+  //future iteration
+  // deleteShelf = (shelfName) => {
+  //   fetch(`https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d/basket/${shelfName}`, {
+  //     method: "DELETE",
+  //     headers: {"Content-Type": "application/json"},
+  //     redirect:'follow'
+  //   })
+  //   .then(response => response.text())
+  //   .then(response => {
+  //     console.log(response)
+  //   })
+  // }
 
   updateItems = (shelfName, itemAdded, weight, amount) => {
     const itemWeight = calcItemWeight(weight, amount)
-    fetch(`https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d/basket/${shelfName}`, {
-      method: "PUT",
-      headers: {"Content-Type": "application/json"},
-      body: JSON.stringify(itemAdded),
-      redirect: "follow"
-    })
-    .then(response => response.json())
+    addItem(shelfName, itemAdded)
     .then(data => {
       this.setState({
         items: {...this.state.items, [shelfName]: data}, totalWeight: this.state.totalWeight + itemWeight

--- a/src/components/Shelves/Shelves.js
+++ b/src/components/Shelves/Shelves.js
@@ -93,7 +93,6 @@ class Shelves extends Component {
       </section>
       <PackStatistics 
       packWeight={this.state.totalWeight} 
-      packItems={this.state.items} 
       shelves={this.state.shelves}
       />
     </main>

--- a/src/components/Shelves/Shelves.js
+++ b/src/components/Shelves/Shelves.js
@@ -1,6 +1,6 @@
 import { React, Component } from "react";
 import { getItems, getShelves, removeItem } from "../../ApiCalls";
-import { calculatePackWeight, createItemList, getShelfItems, calcItemWeight } from "../../utility";
+import { calculatePackWeight, createItemList, getShelfItems, calcItemWeight, calcShelfWeights } from "../../utility";
 import ShelfCard from "../ShelfCard/ShelfCard";
 import PackStatistics from "../PackStatistics/PackStatistics";
 
@@ -19,16 +19,15 @@ class Shelves extends Component {
   componentDidMount() {
     getShelves()
     .then(shelves => {
-      this.setState({shelves: [...this.state.shelves, ...shelves.baskets]})
-    })
-    .then(() => getItems(this.state.shelves))
-    .then(items => {
-      const itemsList = createItemList(items, this.state.shelves);
-      const packWeight = calculatePackWeight(itemsList);
-      this.setState({items: itemsList, totalWeight: packWeight})
-    })
-   .catch(error => console.log(error));
-    
+      getItems(shelves.baskets)
+      .then(items => {
+        const itemsList = createItemList(items, shelves.baskets);
+        const updatedShelves = calcShelfWeights(items, shelves.baskets);
+        const packWeight = calculatePackWeight(itemsList);
+        this.setState({shelves: updatedShelves, items: itemsList, totalWeight: packWeight})
+      })
+     .catch(error => console.log(error));
+    })    
   }
 
   deleteShelf = (shelfName) => {
@@ -73,7 +72,10 @@ class Shelves extends Component {
   }
 
   render() {
-    const shelves = this.state.shelves.map((shelf, i) => {
+    const shelfNames = this.state.shelves.map(shelf => {
+      return Object.keys(shelf); 
+    })
+    const shelves = shelfNames.map((shelf, i) => {
     return <ShelfCard
     key={i}
     id={i}

--- a/src/components/Shelves/Shelves.scss
+++ b/src/components/Shelves/Shelves.scss
@@ -1,10 +1,11 @@
-.shelves {
-  height: 100%; 
-  display: flex; 
+.shelves { 
+  display: flex;
+  align-items: stretch;
+  overflow: scroll;  
 }
 
 .shelves-container {
-  width: 75%; 
+  width: 75%;  
 }
 
 .shelves-intro {

--- a/src/index.scss
+++ b/src/index.scss
@@ -7,6 +7,7 @@
 @import "./components/ShelfCard/ShelfCard.scss";
 @import "./components/ShelfItems/ShelfItems.scss";
 @import "./components/PackStatistics/PackStatistics.scss";
+@import "./components/ShelfStatistics/ShelfStatistics.scss";
 
 html {
   font-size: 62.5%;

--- a/src/utility.js
+++ b/src/utility.js
@@ -7,6 +7,21 @@ export const createItemList = (packItems, shelves) => {
  return itemsList
 }
 
+export const calcShelfWeights = (packItems, shelves) => {
+  const shelfInfo = packItems.reduce((shelfList, shelf, i) => {
+    let shelfTotal = 0; 
+    const shelfItems = Object.values(shelf);
+    shelfItems.forEach(item => {
+      shelfTotal += Number(item.weight) * Number(item.amount)
+    });
+    const currentShelf = shelves[i]; 
+    shelfList.push({[currentShelf]: shelfTotal}) 
+    return shelfList
+  }, []);
+  
+  return shelfInfo
+}
+
 
 export const getShelfItems = (shelfName, itemId, itemList) => {
   const items = itemList[shelfName]
@@ -39,17 +54,19 @@ export const calcItemWeight = (weight, amount) => {
 }
 
 //looking to refactor this
-export const calcShelfWeights = (packItems, shelves) => {
-  const shelfItemList =  Object.values(packItems)
-  const shelfWeights = shelfItemList.reduce((weightList, shelf, i) => {
-   let shelfTotal = 0; 
-   const shelfItems = Object.values(shelf);
-   shelfItems.forEach(item => {
-      shelfTotal += Number(item.weight) * Number(item.amount)
-   });
-    weightList[shelves[i]] = shelfTotal; 
-    return weightList
-  }, {})
-  return shelfWeights 
-}
+// export const calcShelfWeights = (packItems, shelves) => {
+//   const shelfItemList =  Object.values(packItems)
+//   const shelfWeights = shelfItemList.reduce((weightList, shelf, i) => {
+//    let shelfTotal = 0; 
+//    const shelfItems = Object.values(shelf);
+//    shelfItems.forEach(item => {
+//       shelfTotal += Number(item.weight) * Number(item.amount)
+//    });
+//     weightList[shelves[i]] = shelfTotal; 
+//     return weightList
+//   }, {})
+//   return shelfWeights 
+// }
+
+
 

--- a/src/utility.js
+++ b/src/utility.js
@@ -38,3 +38,18 @@ export const calcItemWeight = (weight, amount) => {
   return weightTotal
 }
 
+//looking to refactor this
+export const calcShelfWeights = (packItems, shelves) => {
+  const shelfItemList =  Object.values(packItems)
+  const shelfWeights = shelfItemList.reduce((weightList, shelf, i) => {
+   let shelfTotal = 0; 
+   const shelfItems = Object.values(shelf);
+   shelfItems.forEach(item => {
+      shelfTotal += Number(item.weight) * Number(item.amount)
+   });
+    weightList[shelves[i]] = shelfTotal; 
+    return weightList
+  }, {})
+  return shelfWeights 
+}
+

--- a/src/utility.js
+++ b/src/utility.js
@@ -15,7 +15,7 @@ export const calcShelfWeights = (packItems, shelves) => {
       shelfTotal += Number(item.weight) * Number(item.amount)
     });
     const currentShelf = shelves[i]; 
-    shelfList.push({[currentShelf]: shelfTotal}) 
+    shelfList.push({[currentShelf]: shelfTotal.toFixed(2)}) 
     return shelfList
   }, []);
   


### PR DESCRIPTION
## What does this PR do (summary of changes)?
- A  use can now see a breakdown of each of their shelves and the associate weights. 
- As a user adds and removes items, the weights will dynamically change on the side bar
- Initial styling was implemented
## How should it be tested?
- Load the page, you should see a breakdown of the current weights for each shelf
- add and remove an item, the weight should change accordingly ( use weights with 2 decimal places) 
- The category weights should only display up to 2 decimal points
## Future Iterations:
- add styling to render a different color for each category
