### PR TITLE
Feature/delete shelf

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15,5 +15,6 @@
   </head>
   <body>
     <div class="root" id="root"></div>
+    <div id="removeShelfModal"></div>
   </body>
 </html>

--- a/src/components/AddShelfForm/AddShelfForm.js
+++ b/src/components/AddShelfForm/AddShelfForm.js
@@ -18,7 +18,7 @@ class AddShelfForm extends Component {
   }
 
   clearInputs = () => {
-    this.setState = ({newShelf: "", error: ""})
+    this.setState({newShelf: "", error: ""})
   }
 
   handleSubmit = (event) => {
@@ -29,6 +29,7 @@ class AddShelfForm extends Component {
       this.setState({error: "Please create a shelf name"})
   } else {
     this.props.addShelf(this.state.newShelf.toLowerCase())
+    console.log("test")
     this.clearInputs(); 
   } 
   }
@@ -45,7 +46,7 @@ class AddShelfForm extends Component {
       <input
         className="form-add-shelf-input"
         type="text"
-        value={this.state.value}
+        value={this.state.newShelf}
         name="newShelf"
         onChange={this.handleChange}
       />

--- a/src/components/AddShelfForm/AddShelfForm.js
+++ b/src/components/AddShelfForm/AddShelfForm.js
@@ -8,6 +8,8 @@ class AddShelfForm extends Component {
       newShelf: "",
       error: ""
     }
+    this.handleChange = this.handleChange.bind(this)
+    this.handleSubmit = this.handleSubmit.bind(this)
   }
 
   handleChange = (event) => {

--- a/src/components/RemoveModal/RemoveModal.js
+++ b/src/components/RemoveModal/RemoveModal.js
@@ -1,15 +1,15 @@
 import React from "react";
 import ReactDOM from "react-dom"; 
 
-const RemoveModal = () => {
+const RemoveModal = ({ shelfName, handleModal, handleRemoveShelf }) => {
   return ReactDOM.createPortal((
     <section className="remove-modal-overlay">
       <div className="remove-modal-content">
         <p>Are you sure you want to remove this shelf?</p>
         <p>This will delete the shelf and all it's contents</p>
         <div className="remove-modal-options">
-          <button className="remove-modal-btn">Yes remove please</button>
-          <button className="remove-modal-btn">No take me back</button>
+          <button className="remove-modal-btn" onClick={() => handleRemoveShelf(shelfName)}>Yes remove please</button>
+          <button className="remove-modal-btn" onClick={handleModal}>No take me back</button>
         </div>
       </div>
     </section>

--- a/src/components/RemoveModal/RemoveModal.js
+++ b/src/components/RemoveModal/RemoveModal.js
@@ -1,0 +1,19 @@
+import React from "react";
+import ReactDOM from "react-dom"; 
+
+const RemoveModal = () => {
+  return ReactDOM.createPortal((
+    <section className="remove-modal-overlay">
+      <div className="remove-modal-content">
+        <p>Are you sure you want to remove this shelf?</p>
+        <p>This will delete the shelf and all it's contents</p>
+        <div className="remove-modal-options">
+          <button className="remove-modal-btn">Yes remove please</button>
+          <button className="remove-modal-btn">No take me back</button>
+        </div>
+      </div>
+    </section>
+  ), document.querySelector("#removeShelfModal"))
+}
+
+export default RemoveModal; 

--- a/src/components/RemoveModal/RemoveModal.scss
+++ b/src/components/RemoveModal/RemoveModal.scss
@@ -1,0 +1,32 @@
+.remove-modal-overlay {
+  @include flexStyle(flex, row, align-items, center); 
+  position: fixed;
+  z-index: 1; 
+  left: 0;
+  top: 0;
+  width: 100%; 
+  height: 100%; 
+  background-color: rgb(0,0,0); 
+  background-color: rgba(0,0,0,0.4); 
+}
+
+.remove-modal-content {   
+  background-color: #fefefe;
+  text-align: center; 
+  margin: 8% auto; 
+  padding: 20px;
+  border-radius: 5px; 
+  width: 30%; 
+  height:30%;
+  font-size:1.2em;    
+}
+
+.remove-modal-options {
+  @include flexStyle(flex, row, justify-content, space-evenly); 
+}
+
+.remove-modal-btn {
+  @include buttonStyle($dark-grey, $lime-green);
+  margin: 5px;  
+  padding: 5px; 
+}

--- a/src/components/RemoveModal/RemoveModal.scss
+++ b/src/components/RemoveModal/RemoveModal.scss
@@ -6,7 +6,6 @@
   top: 0;
   width: 100%; 
   height: 100%; 
-  background-color: rgb(0,0,0); 
   background-color: rgba(0,0,0,0.4); 
 }
 

--- a/src/components/ShelfCard/ShelfCard.js
+++ b/src/components/ShelfCard/ShelfCard.js
@@ -49,8 +49,13 @@ class ShelfCard extends Component {
   }
   }
 
-  showModal = () => {
-    this.setState({modalOpen: true})
+  handleModal = () => {
+    this.state.modalOpen ? this.setState({modalOpen: false}) : this.setState({modalOpen: true})
+  }
+
+  handleRemoveShelf = (shelfName) => {
+   this.props.deleteShelf(shelfName)
+   this.handleModal();
   }
 
   render() {
@@ -60,7 +65,7 @@ class ShelfCard extends Component {
         <div className="shelf-category-container">
           <button 
             className="shelf-remove-category-btn"
-            onClick={this.showModal}>
+            onClick={this.handleModal}>
               <IoMdRemoveCircle className="shelf-remove-category-icon"/>
           </button>
           <h2 className="shelf-category">{shelfName}</h2>
@@ -71,7 +76,12 @@ class ShelfCard extends Component {
           >
             <MdExpandMore className={`shelf-expand-icon ${this.state.expanded}`}/>
           </button>
-          {this.state.modalOpen && <RemoveModal/>}
+          {this.state.modalOpen && 
+          <RemoveModal 
+            shelfName={shelfName}
+            handleModal={this.handleModal}
+            handleRemoveShelf={this.handleRemoveShelf}
+          />}
         </div>
         <div className="shelf-expand-container">
           {this.state.error && <p className="form-error-msg">{this.state.error}</p>}

--- a/src/components/ShelfCard/ShelfCard.js
+++ b/src/components/ShelfCard/ShelfCard.js
@@ -1,7 +1,7 @@
 import { React, Component } from "react";
 import ShelfItems from "../ShelfItems/ShelfItems";
-import { MdExpandMore } from "react-icons/md";
-import { MdAdd } from "react-icons/md";
+import { MdAdd, MdRemoveCircle, MdExpandMore } from "react-icons/md";
+import { IoMdRemoveCircle } from "react-icons/io";
 
 class ShelfCard extends Component {
   constructor(props) {
@@ -52,6 +52,10 @@ class ShelfCard extends Component {
     return (
       <article className="shelf-card">
         <div className="shelf-category-container">
+          <button 
+            className="shelf-remove-category-btn">
+              <IoMdRemoveCircle className="shelf-remove-category-icon"/>
+          </button>
           <h2 className="shelf-category">{shelfName}</h2>
           <button 
             className="shelf-expand-btn" 

--- a/src/components/ShelfCard/ShelfCard.js
+++ b/src/components/ShelfCard/ShelfCard.js
@@ -1,7 +1,8 @@
 import { React, Component } from "react";
 import ShelfItems from "../ShelfItems/ShelfItems";
-import { MdAdd, MdRemoveCircle, MdExpandMore } from "react-icons/md";
+import { MdAdd, MdExpandMore } from "react-icons/md";
 import { IoMdRemoveCircle } from "react-icons/io";
+import RemoveModal from "../RemoveModal/RemoveModal";
 
 class ShelfCard extends Component {
   constructor(props) {
@@ -12,6 +13,7 @@ class ShelfCard extends Component {
       amount: "",
       error: "",
       expanded: "collapsed", // use boolean here
+      modalOpen: false
     }
   }
 
@@ -47,13 +49,18 @@ class ShelfCard extends Component {
   }
   }
 
+  showModal = () => {
+    this.setState({modalOpen: true})
+  }
+
   render() {
     const { shelfName, shelfItems, deleteItem } = this.props;
     return (
       <article className="shelf-card">
         <div className="shelf-category-container">
           <button 
-            className="shelf-remove-category-btn">
+            className="shelf-remove-category-btn"
+            onClick={this.showModal}>
               <IoMdRemoveCircle className="shelf-remove-category-icon"/>
           </button>
           <h2 className="shelf-category">{shelfName}</h2>
@@ -64,6 +71,7 @@ class ShelfCard extends Component {
           >
             <MdExpandMore className={`shelf-expand-icon ${this.state.expanded}`}/>
           </button>
+          {this.state.modalOpen && <RemoveModal/>}
         </div>
         <div className="shelf-expand-container">
           {this.state.error && <p className="form-error-msg">{this.state.error}</p>}

--- a/src/components/ShelfCard/ShelfCard.scss
+++ b/src/components/ShelfCard/ShelfCard.scss
@@ -14,6 +14,18 @@
   font-size: 2.8rem;  
 }
 
+.shelf-remove-category-btn {
+  @include removeButtonDefault();
+  margin-left: 20px;
+  width: 3%;
+}
+
+.shelf-remove-category-icon { 
+  color: $dark-grey;
+  width: 90%; 
+  height: 90%; 
+}
+
 .shelf-expand-btn {
   @include removeButtonDefault();
   width: 5%; 
@@ -92,4 +104,6 @@
 .form-add-item-icon:hover {
   filter:drop-shadow(1px 1px 5px $lime-green); 
 }
+
+
 

--- a/src/components/Shelves/Shelves.js
+++ b/src/components/Shelves/Shelves.js
@@ -79,7 +79,6 @@ class Shelves extends Component {
   }
 
   render() {
-    // this.deleteShelf("Water")
     const shelfNames = this.state.shelves.map(shelf => {
       return Object.keys(shelf); 
     })

--- a/src/components/Shelves/Shelves.js
+++ b/src/components/Shelves/Shelves.js
@@ -1,6 +1,6 @@
 import { React, Component } from "react";
 import { addItem, createShelf, getItems, getShelves, removeItem } from "../../ApiCalls";
-import { calculatePackWeight, createItemList, getShelfItems, calcItemWeight, calcShelfWeights } from "../../utility";
+import { calculatePackWeight, createItemList, getShelfItems, calcItemWeight, calcShelfWeights, removeShelf } from "../../utility";
 import ShelfCard from "../ShelfCard/ShelfCard";
 import PackStatistics from "../PackStatistics/PackStatistics";
 import AddShelfForm from "../AddShelfForm/AddShelfForm";
@@ -34,15 +34,13 @@ class Shelves extends Component {
   addShelf = (shelfName) => {
     createShelf(shelfName)
     .then(data => {
+      console.log("test")
       const updatedShelves = [{[shelfName]: 0}].concat(this.state.shelves)
-      console.log(updatedShelves)
       this.setState({shelves: updatedShelves})
     }) 
     .catch(error => console.log(error))
   }
 
-
-  // future iteration
   deleteShelf = (shelfName) => {
     fetch(`https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d/basket/${shelfName}`, {
       method: "DELETE",
@@ -51,7 +49,8 @@ class Shelves extends Component {
     })
     .then(response => response.text())
     .then(data => {
-      console.log(data)
+      const newShelfList = removeShelf(shelfName, this.state.shelves);
+      this.setState({shelves: newShelfList})
     })
   }
 
@@ -82,7 +81,7 @@ class Shelves extends Component {
     const shelfNames = this.state.shelves.map(shelf => {
       return Object.keys(shelf); 
     })
-    const shelves = shelfNames.map((shelf, i) => {
+    const shelves = shelfNames.flat().map((shelf, i) => {
     return <ShelfCard
       key={i}
       id={i}
@@ -90,6 +89,7 @@ class Shelves extends Component {
       shelfItems={this.state.items[shelf]}
       updateItems={this.updateItems}
       deleteItem={this.deleteItem}
+      deleteShelf={this.deleteShelf}
     />
   })
   return (

--- a/src/components/Shelves/Shelves.js
+++ b/src/components/Shelves/Shelves.js
@@ -34,9 +34,9 @@ class Shelves extends Component {
   addShelf = (shelfName) => {
     createShelf(shelfName)
     .then(data => {
-      console.log("test")
       const updatedShelves = [{[shelfName]: 0}].concat(this.state.shelves)
       this.setState({shelves: updatedShelves})
+      console.log("test")
     }) 
     .catch(error => console.log(error))
   }

--- a/src/index.scss
+++ b/src/index.scss
@@ -9,6 +9,7 @@
 @import "./components/PackStatistics/PackStatistics.scss";
 @import "./components/ShelfStatistics/ShelfStatistics.scss";
 @import "./components/AddShelfForm/AddShelfForm.scss";
+@import "./components/RemoveModal/RemoveModal";
 
 html {
   font-size: 62.5%;

--- a/src/utility.js
+++ b/src/utility.js
@@ -54,7 +54,6 @@ export const calcItemWeight = (weight, amount) => {
 }
 
 export const checkShelves = (shelves, shelfName) => {
-  
   const shelfNames = shelves.map(shelf => {
     const shelfName =  Object.keys(shelf);
     return shelfName[0]; 
@@ -64,6 +63,15 @@ export const checkShelves = (shelves, shelfName) => {
   }
   return false; 
 
+}
+
+export const removeShelf = (shelfName, shelves) => {
+  const removedShelfIndex = shelves.findIndex(shelf => {
+    const currentShelfName =  Object.keys(shelf)[0]
+    return currentShelfName === shelfName
+  });
+  shelves.splice(removedShelfIndex, 1)
+  return shelves; 
 }
 
 


### PR DESCRIPTION
## What does this PR do (summary of changes)?
- A user can now delete a shelf from their shelf list
- a delete icon was added to each shelf listing
- A modal component was added which asks the user if they are positive they want to delete the shelf and gives them the option to go back or to delete the shelf. It explains that all the contents of the shelf will also be gone
- A delete method was written along with some utility functions that remove the shelf item
- Styling was added to the modal and to the delete button
- a bug was discovered and fixed with the add shelf form. When a user added an item, but went to add another item, the app crashed. This bug was fixed, there was an improper use of this.setstate()
## How should it be tested?
- Go to the app and delete a few shelves, you should see a modal pop up with two options
   - click on the "no take me back" option and the modal should disappear
   - click on the "yes remove please" option and the modal should disappear, and the shelf should visibly be removed from the list
- on refresh the shelf should no longer appear
## Future Iterations:
- find a way to style the inside of the icon (the remove line) so it is lime green and matches the color palette
