### PR TITLE
Feature/display category weights

### DIFF
--- a/src/ApiCalls.js
+++ b/src/ApiCalls.js
@@ -50,3 +50,12 @@ export const createShelf = (shelfName) => {
   })
   .then(response => response.text())
 }
+
+export const deleteCurrentShelf = (shelfName) => {
+  return fetch(`${baseURL}/basket/${shelfName}`, {
+    method: "DELETE",
+    headers: {"Content-Type": "application/json"},
+    redirect:'follow'
+  })
+  .then(response => response.text())
+}

--- a/src/components/AddShelfForm/AddShelfForm.js
+++ b/src/components/AddShelfForm/AddShelfForm.js
@@ -8,8 +8,6 @@ class AddShelfForm extends Component {
       newShelf: "",
       error: ""
     }
-    this.handleChange = this.handleChange.bind(this)
-    this.handleSubmit = this.handleSubmit.bind(this)
   }
 
   handleChange = (event) => {
@@ -28,8 +26,7 @@ class AddShelfForm extends Component {
   } else if (!this.state.newShelf) {
       this.setState({error: "Please create a shelf name"})
   } else {
-    this.props.addShelf(this.state.newShelf.toLowerCase())
-    console.log("test")
+    this.props.addShelf(this.state.newShelf)
     this.clearInputs(); 
   } 
   }

--- a/src/components/PackStatistics/PackStatistics.scss
+++ b/src/components/PackStatistics/PackStatistics.scss
@@ -1,6 +1,6 @@
 .statistics {
   background-color: $lime-green;
-  width: 25%;
+  width: 30%;
   min-height: 100%; 
 }
 

--- a/src/components/ShelfStatistics/ShelfStatistics.js
+++ b/src/components/ShelfStatistics/ShelfStatistics.js
@@ -11,7 +11,7 @@ const ShelfStatistics = ({ shelves }) => {
       >
           <span className="statistics-category-name">{shelfWeightInfoOz[0]}:</span>
           <span className="statistics-category-oz">{shelfWeightInfoOz[1]} Oz</span> | 
-          <span className="statistics-category-lbs">{shelfWeightInfoLbs} Lbs </span>
+          <span className="statistics-category-lbs">  {shelfWeightInfoLbs} Lbs </span>
       </li>
     )
   })

--- a/src/components/ShelfStatistics/ShelfStatistics.js
+++ b/src/components/ShelfStatistics/ShelfStatistics.js
@@ -2,19 +2,22 @@ import React from "react";
 
 const ShelfStatistics = ({ shelves }) => {
   const shelfWeights = shelves.map((shelf, i) => {
-    const shelfWeightInfo = Object.entries(shelf).flat()
+    const shelfWeightInfoOz = Object.entries(shelf).flat()
+    const shelfWeightInfoLbs = (shelfWeightInfoOz[1] / 16).toFixed(2); 
     return (
       <li 
         key={i}
         className="statistics-category"
       >
-          <span className="statistics-category-title">{shelfWeightInfo[0]}:</span>{shelfWeightInfo[1]} 
+          <span className="statistics-category-name">{shelfWeightInfoOz[0]}:</span>
+          <span className="statistics-category-oz">{shelfWeightInfoOz[1]} Oz</span> | 
+          <span className="statistics-category-lbs">{shelfWeightInfoLbs} Lbs </span>
       </li>
     )
   })
   return (
     <div className="statistics-category-container">
-      <h2>The Breakdown</h2>
+      <h2 className="statistics-category-title">The Breakdown</h2>
       <ul className="statistics-category-list">
         {shelfWeights}
       </ul>

--- a/src/components/ShelfStatistics/ShelfStatistics.scss
+++ b/src/components/ShelfStatistics/ShelfStatistics.scss
@@ -3,6 +3,11 @@
   margin: 10px;   
 }
 
+.statistics-category-title {
+  font-size: 2.8rem; 
+  text-align: center;
+}
+
 .statistics-category-list {
   list-style-type: none;
   padding: 0;
@@ -14,7 +19,15 @@
   padding: 10px;  
 }
 
-.statistics-category-title {
+.statistics-category-name { 
   margin-right: 10px;
-  font-weight: 600;  
+  font-weight: 600;   
+}
+
+.statistics-category-oz {
+  color: rgb(176, 24, 199);
+}
+
+.statistics-category-lbs {
+  color: rgb(255, 89, 0);
 }

--- a/src/components/Shelves/Shelves.js
+++ b/src/components/Shelves/Shelves.js
@@ -54,7 +54,7 @@ class Shelves extends Component {
   }
 
   updateItems = (shelfName, itemAdded, weight, amount) => {
-    const updatedShelves = updateShelfWeight(this.state.shelves, shelfName, weight, amount); 
+    const updatedShelves = updateShelfWeight(this.state.shelves, shelfName, weight, amount, true); 
     const itemWeight = calcItemWeight(weight, amount)
     addItem(shelfName, itemAdded)
     .then(data => {
@@ -67,11 +67,12 @@ class Shelves extends Component {
   }
 
   deleteItem = (shelfName, itemId, weight, amount) => {
+    const updatedShelves = updateShelfWeight(this.state.shelves, shelfName, weight, amount, false); 
     const itemWeight = calcItemWeight(weight, amount); 
     const updatedItems = getShelfItems(shelfName, itemId, this.state.items);
     removeItem(shelfName, updatedItems)
     .then(data => {
-       this.setState({items: {...this.state.items, [shelfName]: updatedItems}, totalWeight: this.state.totalWeight - itemWeight})
+       this.setState({items: {...this.state.items, [shelfName]: updatedItems}, shelves: updatedShelves,  totalWeight: this.state.totalWeight - itemWeight})
     })
     .catch(error => {
       this.setState({error: "We're sorry, we cannot remove this item right now, please try again later"})

--- a/src/components/Shelves/Shelves.js
+++ b/src/components/Shelves/Shelves.js
@@ -1,6 +1,6 @@
 import { React, Component } from "react";
 import { addItem, createShelf, getItems, getShelves, removeItem } from "../../ApiCalls";
-import { calculatePackWeight, createItemList, getShelfItems, calcItemWeight, calcShelfWeights, removeShelf } from "../../utility";
+import { calculatePackWeight, createItemList, getShelfItems, calcItemWeight, calcShelfWeights, removeShelf, updateShelfWeight } from "../../utility";
 import ShelfCard from "../ShelfCard/ShelfCard";
 import PackStatistics from "../PackStatistics/PackStatistics";
 import AddShelfForm from "../AddShelfForm/AddShelfForm";
@@ -36,7 +36,6 @@ class Shelves extends Component {
     .then(data => {
       const updatedShelves = [{[shelfName]: 0}].concat(this.state.shelves)
       this.setState({shelves: updatedShelves})
-      console.log("test")
     }) 
     .catch(error => console.log(error))
   }
@@ -55,11 +54,13 @@ class Shelves extends Component {
   }
 
   updateItems = (shelfName, itemAdded, weight, amount) => {
+    const updatedShelves = updateShelfWeight(this.state.shelves, shelfName, weight, amount); 
     const itemWeight = calcItemWeight(weight, amount)
     addItem(shelfName, itemAdded)
     .then(data => {
+      console.log(data)
       this.setState({
-        items: {...this.state.items, [shelfName]: data}, totalWeight: this.state.totalWeight + itemWeight
+        items: {...this.state.items, [shelfName]: data}, shelves: updatedShelves,  totalWeight: this.state.totalWeight + itemWeight
       })
     })
     .catch(error => console.log(error))

--- a/src/components/Shelves/Shelves.js
+++ b/src/components/Shelves/Shelves.js
@@ -24,7 +24,7 @@ class Shelves extends Component {
       .then(items => {
         const itemsList = createItemList(items, shelves.baskets);
         const updatedShelves = calcShelfWeights(items, shelves.baskets);
-        const packWeight = calculatePackWeight(itemsList);
+        const packWeight = calculatePackWeight(updatedShelves);
         this.setState({shelves: updatedShelves, items: itemsList, totalWeight: packWeight})
       })
      .catch(error => console.log(error));

--- a/src/components/Shelves/Shelves.js
+++ b/src/components/Shelves/Shelves.js
@@ -1,6 +1,6 @@
 import { React, Component } from "react";
 import { addItem, createShelf, getItems, getShelves, removeItem, deleteCurrentShelf } from "../../ApiCalls";
-import { calculatePackWeight, createItemList, getShelfItems, calcItemWeight, calcShelfWeights, removeShelf, updateShelfWeight } from "../../utility";
+import { calculatePackWeight, createItemList, updateShelfItems, calcItemWeight, calcShelfWeights, removeShelf, updateShelfWeight } from "../../utility";
 import ShelfCard from "../ShelfCard/ShelfCard";
 import PackStatistics from "../PackStatistics/PackStatistics";
 import AddShelfForm from "../AddShelfForm/AddShelfForm";
@@ -64,10 +64,10 @@ class Shelves extends Component {
   deleteItem = (shelfName, itemId, weight, amount) => {
     const updatedShelves = updateShelfWeight(this.state.shelves, shelfName, weight, amount, false); 
     const itemWeight = calcItemWeight(weight, amount); 
-    const updatedItems = getShelfItems(shelfName, itemId, this.state.items);
-    removeItem(shelfName, updatedItems)
+    const updatedItemsList = updateShelfItems(shelfName, itemId, this.state.items);
+    removeItem(shelfName, updatedItemsList)
     .then(data => {
-       this.setState({items: {...this.state.items, [shelfName]: updatedItems}, shelves: updatedShelves,  totalWeight: this.state.totalWeight - itemWeight})
+       this.setState({items: {...this.state.items, [shelfName]: updatedItemsList}, shelves: updatedShelves,  totalWeight: this.state.totalWeight - itemWeight})
     })
     .catch(error => {
       this.setState({error: "We're sorry, we cannot remove this item right now, please try again later"})

--- a/src/components/Shelves/Shelves.js
+++ b/src/components/Shelves/Shelves.js
@@ -34,7 +34,7 @@ class Shelves extends Component {
   addShelf = (shelfName) => {
     createShelf(shelfName)
     .then(data => {
-      const updatedShelves = [{[shelfName]: 0}].concat(this.state.shelves)
+      const updatedShelves = [{[shelfName]: "0.00"}].concat(this.state.shelves)
       this.setState({shelves: updatedShelves})
     }) 
     .catch(error => console.log(error))
@@ -53,7 +53,6 @@ class Shelves extends Component {
     const itemWeight = calcItemWeight(weight, amount)
     addItem(shelfName, itemAdded)
     .then(data => {
-      console.log(data)
       this.setState({
         items: {...this.state.items, [shelfName]: data}, shelves: updatedShelves,  totalWeight: this.state.totalWeight + itemWeight
       })

--- a/src/components/Shelves/Shelves.js
+++ b/src/components/Shelves/Shelves.js
@@ -1,5 +1,5 @@
 import { React, Component } from "react";
-import { addItem, createShelf, getItems, getShelves, removeItem } from "../../ApiCalls";
+import { addItem, createShelf, getItems, getShelves, removeItem, deleteCurrentShelf } from "../../ApiCalls";
 import { calculatePackWeight, createItemList, getShelfItems, calcItemWeight, calcShelfWeights, removeShelf, updateShelfWeight } from "../../utility";
 import ShelfCard from "../ShelfCard/ShelfCard";
 import PackStatistics from "../PackStatistics/PackStatistics";
@@ -41,12 +41,7 @@ class Shelves extends Component {
   }
 
   deleteShelf = (shelfName) => {
-    fetch(`https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d/basket/${shelfName}`, {
-      method: "DELETE",
-      headers: {"Content-Type": "application/json"},
-      redirect:'follow'
-    })
-    .then(response => response.text())
+    deleteCurrentShelf(shelfName)
     .then(data => {
       const newShelfList = removeShelf(shelfName, this.state.shelves);
       this.setState({shelves: newShelfList})

--- a/src/components/Shelves/Shelves.scss
+++ b/src/components/Shelves/Shelves.scss
@@ -5,7 +5,7 @@
 }
 
 .shelves-container {
-  width: 75%;  
+  width: 70%;  
 }
 
 .shelves-intro {

--- a/src/utility.js
+++ b/src/utility.js
@@ -50,19 +50,13 @@ export const getShelfItems = (shelfName, itemId, itemList) => {
   return items; 
 }
 
-export const calculatePackWeight = (allShelfItems) => {
-  const packItemsList = Object.values(allShelfItems)
-  const weight = packItemsList.reduce((total, shelfItems) => {
-    if(Object.keys(shelfItems).length) {
-      const items = Object.values(shelfItems)
-        items.forEach(item => {
-          total += Number(item.weight * item.amount);
-      });
-    }
-    return total
+export const calculatePackWeight = (shelves) => {
+  const packWeight = shelves.reduce((totalWeight, shelf) => {
+    const shelfWeight = parseFloat(Object.values(shelf).flat()[0]); 
+    totalWeight += shelfWeight; 
+    return totalWeight
   }, 0);
-  
-  return weight
+  return packWeight; 
 }
 
 export const calcItemWeight = (weight, amount) => {

--- a/src/utility.js
+++ b/src/utility.js
@@ -22,14 +22,18 @@ export const calcShelfWeights = (packItems, shelves) => {
   return shelfInfo
 }
 
-export const updateShelfWeight = (shelves, shelfName, weight, amount) => {
+export const updateShelfWeight = (shelves, shelfName, weight, amount, action) => {
   const weightToAdd = parseFloat(weight * amount); 
   const updatedShelves = shelves.map(shelf => {
      const currentShelfName = Object.keys(shelf)[0]
-    if(currentShelfName === shelfName) {
-       shelf[shelfName] = (parseFloat(shelf[shelfName]) + weightToAdd).toFixed(2);
+    if(currentShelfName === shelfName && action) {
+       shelf[shelfName] = (parseFloat(shelf[shelfName]) + weightToAdd).toFixed(2)
        return shelf;
-    }
+    } 
+    if(currentShelfName === shelfName && !action) {
+      shelf[shelfName] = (parseFloat(shelf[shelfName]) - weightToAdd).toFixed(2)
+       return shelf;
+    }   
     return shelf; 
   })
   return updatedShelves ;

--- a/src/utility.js
+++ b/src/utility.js
@@ -40,7 +40,7 @@ export const updateShelfWeight = (shelves, shelfName, weight, amount, action) =>
 }
 
 
-export const getShelfItems = (shelfName, itemId, itemList) => {
+export const updateShelfItems = (shelfName, itemId, itemList) => {
   const items = itemList[shelfName]
   for(const itemName in items) {
     if(items[itemName].id === itemId) {

--- a/src/utility.js
+++ b/src/utility.js
@@ -22,6 +22,19 @@ export const calcShelfWeights = (packItems, shelves) => {
   return shelfInfo
 }
 
+export const updateShelfWeight = (shelves, shelfName, weight, amount) => {
+  const weightToAdd = parseFloat(weight * amount); 
+  const updatedShelves = shelves.map(shelf => {
+     const currentShelfName = Object.keys(shelf)[0]
+    if(currentShelfName === shelfName) {
+       shelf[shelfName] = (parseFloat(shelf[shelfName]) + weightToAdd).toFixed(2);
+       return shelf;
+    }
+    return shelf; 
+  })
+  return updatedShelves ;
+}
+
 
 export const getShelfItems = (shelfName, itemId, itemList) => {
   const items = itemList[shelfName]


### PR DESCRIPTION
## What does this PR do (summary of changes)?
- A user will now see the weights for each shelf dynamically change as they enter and remove items from their shelves
- A helper method was created to calculate the new weight so it can be rendered for the user
- A refactor was done on calculate pack weight to use the shelf weights that are calculated onload instead of the master item list
- The delete shelf API call was not broken out into the apiCalls.js file, so a refactor was done on this method
- Some naming was changed on utility functions called inside of delete item for clarity
- a Lbs stat was added for each category, and styling was applied to category weight breakdown
## How should it be tested?
- Add a few items to a shelf and see that the shelf weight is changing
- remove a few items from a shelf and see that the shelf weight is changing
## Future Iterations:
- none at this time
