### PR TITLE
Error messages

### DIFF
--- a/src/ApiCalls.js
+++ b/src/ApiCalls.js
@@ -15,7 +15,7 @@ export const getShelves = () => {
 
 export const getItems = (shelves) => {
   const items = shelves.map(shelf => {
-    return fetch(`${baseURL}/basket/${shelf}`)
+    return fetch(`${baseURL}/baske/${shelf}`)
    .then(response => checkForErrors(response))
   }) 
   return Promise.all(items)

--- a/src/ApiCalls.js
+++ b/src/ApiCalls.js
@@ -15,7 +15,7 @@ export const getShelves = () => {
 
 export const getItems = (shelves) => {
   const items = shelves.map(shelf => {
-    return fetch(`${baseURL}/baske/${shelf}`)
+    return fetch(`${baseURL}/basket/${shelf}`)
    .then(response => checkForErrors(response))
   }) 
   return Promise.all(items)

--- a/src/components/Shelves/Shelves.js
+++ b/src/components/Shelves/Shelves.js
@@ -99,7 +99,8 @@ class Shelves extends Component {
           addShelf={this.addShelf}
           shelves={this.state.shelves}
         />
-        {this.state.error && <p className="shelves-loading-error-msg">{this.state.error}</p>}
+        {this.state.error && <p className="shelves-loading-msg">{this.state.error}</p>}
+        {!this.state.error && !this.state.shelves.length && <p className="shelves-loading-msg">Loading shelves...</p>}
         {shelves}
       </section>
       <PackStatistics 

--- a/src/components/Shelves/Shelves.js
+++ b/src/components/Shelves/Shelves.js
@@ -14,6 +14,7 @@ class Shelves extends Component {
       shelves: [],
       items: {},
       totalWeight: 0,
+      error: ""
     }
   }
 
@@ -27,7 +28,9 @@ class Shelves extends Component {
         const packWeight = calculatePackWeight(updatedShelves);
         this.setState({shelves: updatedShelves, items: itemsList, totalWeight: packWeight})
       })
-     .catch(error => console.log(error));
+     .catch(error => {
+       this.setState({error: "We can't load your shelves right now, please try again later"})
+     });
     })    
   }
 
@@ -96,6 +99,7 @@ class Shelves extends Component {
           addShelf={this.addShelf}
           shelves={this.state.shelves}
         />
+        {this.state.error && <p className="shelves-loading-error-msg">{this.state.error}</p>}
         {shelves}
       </section>
       <PackStatistics 

--- a/src/components/Shelves/Shelves.scss
+++ b/src/components/Shelves/Shelves.scss
@@ -15,10 +15,11 @@
   font-weight: 600;    
 }
 
-.shelves-loading-error-msg {
+.shelves-loading-msg {
   text-align: center;
   font-size: 1.8em; 
 }
+
 
 
 

--- a/src/components/Shelves/Shelves.scss
+++ b/src/components/Shelves/Shelves.scss
@@ -15,5 +15,10 @@
   font-weight: 600;    
 }
 
+.shelves-loading-error-msg {
+  text-align: center;
+  font-size: 1.8em; 
+}
+
 
 


### PR DESCRIPTION
## What does this PR do (summary of changes)?
- Error handling was added for loading all the data on initial visit
- A helpful error message will display to the user when an error occurs fetching the shelf data
- A loading message appears for the user while the shelf data is being fetched 
## How should it be tested?
- in the addItems api call, delete the letter "t" in the URL and reload, you should see an error message appear for the user
- Fix the URL back to normal, and reload the dashboard, you should see a "Loading shelves..." message appear before the data is rendered
## Future Iterations:
- none at this time
