### PR TITLE
Use new state property to conditionally render shelves empty msg

### DIFF
--- a/src/components/ShelfCard/ShelfCard.js
+++ b/src/components/ShelfCard/ShelfCard.js
@@ -36,7 +36,7 @@ class ShelfCard extends Component {
       this.setState({error: "Please fill out all the fields"})
   } else {
     this.setState({error: ""});
-    this.props.updateItems(shelfName, itemAdded,this.state.itemName, this.state.weight, this.state.amount)
+    this.props.updateItems(shelfName, itemAdded, this.state.weight, this.state.amount)
     this.clearInputs(); 
   }
   }

--- a/src/components/Shelves/Shelves.js
+++ b/src/components/Shelves/Shelves.js
@@ -14,7 +14,8 @@ class Shelves extends Component {
       shelves: [],
       items: {},
       totalWeight: 0,
-      error: ""
+      error: "",
+      shelvesEmpty: false
     }
   }
 
@@ -26,7 +27,11 @@ class Shelves extends Component {
         const itemsList = createItemList(items, shelves.baskets);
         const updatedShelves = calcShelfWeights(items, shelves.baskets);
         const packWeight = calculatePackWeight(updatedShelves);
-        this.setState({shelves: updatedShelves, items: itemsList, totalWeight: packWeight})
+        if(!updatedShelves.length) {
+          this.setState({shelves: updatedShelves, items: itemsList, totalWeight: packWeight, shelvesEmpty: true})
+      } else {
+          this.setState({shelves: updatedShelves, items: itemsList, totalWeight: packWeight, shelvesEmpty: false})
+      }
       })
      .catch(error => {
        this.setState({error: "We can't load your shelves right now, please try again later"})
@@ -38,7 +43,7 @@ class Shelves extends Component {
     createShelf(shelfName)
     .then(data => {
       const updatedShelves = [{[shelfName]: "0.00"}].concat(this.state.shelves)
-      this.setState({shelves: updatedShelves})
+      this.setState({shelves: updatedShelves, shelvesEmpty: false})
     }) 
     .catch(error => console.log(error))
   }
@@ -46,14 +51,17 @@ class Shelves extends Component {
   deleteShelf = (shelfName) => {
     deleteCurrentShelf(shelfName)
     .then(data => {
-      console.log(data)
       const newShelfList = removeShelf(shelfName, this.state.shelves);
-      const newPackWeight = calculatePackWeight(newShelfList); 
-      this.setState({shelves: newShelfList, totalWeight: newPackWeight})
+      const newPackWeight = calculatePackWeight(newShelfList);
+      if(!newShelfList.length) {
+        this.setState({shelves: newShelfList, totalWeight: newPackWeight, shelvesEmpty: true})
+    } else {
+        this.setState({shelves: newShelfList, totalWeight: newPackWeight})
+    }
     })
   }
 
-  updateItems = (shelfName, itemAdded, itemName, weight, amount) => {
+  updateItems = (shelfName, itemAdded, weight, amount) => {
     const updatedShelves = updateShelfWeight(this.state.shelves, shelfName, weight, amount, true); 
     const itemWeight = calcItemWeight(weight, amount)
     addItem(shelfName, itemAdded)
@@ -80,7 +88,6 @@ class Shelves extends Component {
   }
 
   render() {
-  
     const shelfNames = this.state.shelves.map(shelf => {
       return Object.keys(shelf); 
     })
@@ -104,7 +111,8 @@ class Shelves extends Component {
           shelves={this.state.shelves}
         />
         {this.state.error && <p className="shelves-loading-msg" data-cy="loading-msg">{this.state.error}</p>}
-        {!this.state.error && !this.state.shelves.length && <p className="shelves-loading-msg">Loading shelves...</p>}
+        {!this.state.error && !this.state.shelves.length && !this.state.shelvesEmpty && <p className="shelves-loading-msg">Loading shelves...</p>}
+        {this.state.shelvesEmpty && <p className="shelves-loading-msg">Your shelves are empty</p>}
         {shelves}
       </section>
       <PackStatistics 


### PR DESCRIPTION
## What does this PR do (summary of changes)?
- When A user visits the page a loading message is rendered while the shelves are loaded, however, when the shelves were empty, the loading shelves message still appeared, and this bug was addressed
- Now when the shelves are empty on load and when a user deletes their last shelf, a new message will appear stating that the shelves are empty
## How should it be tested?
- on load if there are any shelves, delete all the shelves and a "Your shelves are empty" message should appear
- after all shelves are deleted, refresh the dashboard, the "Your shelves are empty" message should appear
## Future Iterations:
-none at this time
