### PR TITLE
Bug/duplicate item additions

### DIFF
--- a/cypress/integration/examples/app_spec.js
+++ b/cypress/integration/examples/app_spec.js
@@ -46,7 +46,7 @@ describe("User Dashboard", () => {
     cy.get("[data-cy=shelf-weight-lb]").contains("2.50 Lbs");
   });
 
-  it.only("should take a user back to the landing page", () => {
+  it("should take a user back to the landing page", () => {
     cy.get("[data-cy=home-link]").click();
     cy.url().should('include', '/');
     cy.get("[data-cy=user-portal]").should("contain", "Gearfull");
@@ -121,6 +121,15 @@ describe("Adding an item", () => {
     cy.get("[data-cy=item-add-btn]").first().click();
     cy.get("[data-cy=form-error-msg]").contains("Please fill out all the fields");
     cy.get("[data-cy=added-item]").eq(1).should("not.exist");
+  });
+
+  it("should give the user an error message if they add a duplicate item", () => {
+    cy.get("[data-cy=expand-shelf-btn]").first().click();
+    cy.get("[data-cy=item-name-input]").first().type("garmin");
+    cy.get("[data-cy=item-weight-input]").first().type("34.6");
+    cy.get("[data-cy=item-amount-input]").first().type("1");
+    cy.get("[data-cy=item-add-btn]").first().click();
+    cy.get("[data-cy=form-error-msg]").contains("This item already exists"); 
   });
 
   it("should hide the form error message if successful submission was made", () => {

--- a/cypress/integration/examples/app_spec.js
+++ b/cypress/integration/examples/app_spec.js
@@ -51,20 +51,32 @@ describe("User Dashboard", () => {
     cy.url().should('include', '/');
     cy.get("[data-cy=user-portal]").should("contain", "Gearfull");
 
-  })
+  });
 });
 
-describe("Loading messages", () => {
+describe.only("Loading messages", () => {
   it("should show an error message if shelves can't be loaded", () => {
-    cy.intercept("https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d", {fixture:"shelves.json"});
+
+    cy.intercept({
+      method: 'GET',
+      url: 'https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d/basket/navigation'
+    },
+    {
+      statusCode: 500,
+      body: { 
+        message: `Shelves can't be loaded at this time` 
+      }
+    })
+    cy.intercept("https://getpantry.cloud/apiv1/pantry/shelferror", {fixture:"shelves.json"});
     cy.visit("http://localhost:3000/dashboard");
     cy.get("[data-cy=loading-error-msg]").contains("We can't load your shelves right now, please try again later");
   });
 
   it("should show a loading message if shelves are loading", () => {
-    cy.intercept(`https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d/basket/navigation`, {fixture: "item1.json"});
+
     cy.intercept("https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d", {fixture:"shelves.json"});
-    cy.visit("http://localhost:3000/dashboard");
+    cy.intercept(`https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d/basket/navigation`, {fixture: "item1.json"});
+    cy.visit("http://localhost:3000/dashboard")
     cy.contains('Loading shelves...');
 
   });
@@ -74,8 +86,8 @@ describe("Loading messages", () => {
     cy.visit("http://localhost:3000/dashboard");
     cy.contains("Your shelves are empty");
 
-  })
-})
+  });
+});
 
 describe("Adding an item", () => {
   beforeEach(() => {

--- a/src/components/ShelfCard/ShelfCard.js
+++ b/src/components/ShelfCard/ShelfCard.js
@@ -31,6 +31,7 @@ class ShelfCard extends Component {
     const itemAdded = {
       [itemName]: {id: Date.now(), weight: this.state.weight, amount: this.state.amount}
     }
+    console.log(this.props.shelfItems)
     event.preventDefault()
     if(!this.state.itemName || !this.state.weight || !this.state.amount) {
       this.setState({error: "Please fill out all the fields"})

--- a/src/components/ShelfCard/ShelfCard.js
+++ b/src/components/ShelfCard/ShelfCard.js
@@ -27,14 +27,16 @@ class ShelfCard extends Component {
   }
 
   handleSubmit = (event, shelfName) => {
+    event.preventDefault()
     const itemName = this.state.itemName.toLowerCase()
     const itemAdded = {
       [itemName]: {id: Date.now(), weight: this.state.weight, amount: this.state.amount}
     }
-    console.log(this.props.shelfItems)
-    event.preventDefault()
+    const isDuplicate = Object.keys(this.props.shelfItems).includes(itemName)
     if(!this.state.itemName || !this.state.weight || !this.state.amount) {
       this.setState({error: "Please fill out all the fields"})
+  } else if(isDuplicate) {
+      this.setState({error: "This item already exists"})
   } else {
     this.setState({error: ""});
     this.props.updateItems(shelfName, itemAdded, this.state.weight, this.state.amount)

--- a/src/components/ShelfItems/ShelfItems.scss
+++ b/src/components/ShelfItems/ShelfItems.scss
@@ -1,17 +1,17 @@
 .shelf-item-list {
-  position: relative; 
   list-style-type: none;
   padding: 0px; 
   margin: 0; 
 }
 
 .shelf-item {
+  position: relative;
   display: flex;
   border-bottom: thin solid $lime-green;
   padding-left: 20px;  
 }
 
-.shelf-item-name {
+.shelf-item-name { 
   width: 50%;
   font-weight: 600; 
   font-size: 1.2em;  

--- a/src/utility.js
+++ b/src/utility.js
@@ -73,7 +73,6 @@ export const checkShelves = (shelves, shelfName) => {
     return true;
   }
   return false; 
-
 }
 
 export const removeShelf = (shelfName, shelves) => {


### PR DESCRIPTION
## What does this PR do (summary of changes)?
- A bug was addressed, When a user added a duplicate item, the weight was adjusted in the statistics box, but the item was not updated in the list
- To address this issues, users are prevented from adding duplicate items and will be shown an error message if they are adding the same item
- Testing was added for this new user flow
- Testing was also updated to stub a loading error message properly
## How should it be tested?
- Inside the dashboard, add an item, and then try to add the same item, you should see an error message telling you that it is a duplicate item
- The item should not be added to the list or processed
## Future Iterations:
- none at this time
