### PR TITLE
Fix undefined prop error, update items when shelf is added

### DIFF
--- a/src/components/Shelves/Shelves.js
+++ b/src/components/Shelves/Shelves.js
@@ -43,7 +43,7 @@ class Shelves extends Component {
     createShelf(shelfName)
     .then(data => {
       const updatedShelves = [{[shelfName]: "0.00"}].concat(this.state.shelves)
-      this.setState({shelves: updatedShelves, shelvesEmpty: false})
+      this.setState({items: {...this.state.items, [shelfName]: {}} ,shelves: updatedShelves, shelvesEmpty: false})
     }) 
     .catch(error => console.log(error))
   }
@@ -102,6 +102,7 @@ class Shelves extends Component {
       deleteShelf={this.deleteShelf}
     />
   })
+  
   return (
     <main className="shelves">
       <section className="shelves-container" data-cy="shelves" >


### PR DESCRIPTION
## What does this PR do (summary of changes)?
- A bug was discovered during testing
- When shelves are empty and the page was refreshed, the prop for shelf card was coming in undefined
  - it was discovered that when a shelf was added, the shelves array was updated, but the items was not updated to reflect that shelf with an empty item list,
  - when calling on a key of that shelfItem object to pass to each shelf card, the prop was undefined and caused the app to crash
- Now when the page is loaded without any shelves, and a shelf is added, the items list is updated to reflect the shelf additon
## How should it be tested?
- delete all shelves, refresh the page and add a shelf
- The shelf should appear
- the state should reflect an items object with a key of the shelf name and it's value should be an empty object
## Future Iterations:
- none at this time
