### PR TITLE
Fix/Delete-shelf-update-state

### DIFF
--- a/src/components/Shelves/Shelves.js
+++ b/src/components/Shelves/Shelves.js
@@ -1,6 +1,6 @@
 import { React, Component } from "react";
 import { addItem, createShelf, getItems, getShelves, removeItem, deleteCurrentShelf } from "../../ApiCalls";
-import { calculatePackWeight, createItemList, updateShelfItems, calcItemWeight, calcShelfWeights, removeShelf, updateShelfWeight } from "../../utility";
+import { calculatePackWeight, createItemList, updateShelfItems, calcItemWeight, calcShelfWeights, removeShelf, updateShelfWeight, updateItemList } from "../../utility";
 import ShelfCard from "../ShelfCard/ShelfCard";
 import PackStatistics from "../PackStatistics/PackStatistics";
 import AddShelfForm from "../AddShelfForm/AddShelfForm";
@@ -53,10 +53,11 @@ class Shelves extends Component {
     .then(data => {
       const newShelfList = removeShelf(shelfName, this.state.shelves);
       const newPackWeight = calculatePackWeight(newShelfList);
+      const newItemList = updateItemList(this.state.items, shelfName)
       if(!newShelfList.length) {
-        this.setState({shelves: newShelfList, totalWeight: newPackWeight, shelvesEmpty: true})
+        this.setState({items: {}, shelves: newShelfList, totalWeight: newPackWeight, shelvesEmpty: true})
     } else {
-        this.setState({shelves: newShelfList, totalWeight: newPackWeight})
+        this.setState({items: newItemList, shelves: newShelfList, totalWeight: newPackWeight})
     }
     })
   }

--- a/src/utility.js
+++ b/src/utility.js
@@ -50,6 +50,15 @@ export const updateShelfItems = (shelfName, itemId, itemList) => {
   return items; 
 }
 
+export const updateItemList = (items, shelfName) => {
+  for( const item in items) {
+    if(item === shelfName) {
+      delete items[item]
+    }
+  }
+  return items
+}
+
 export const calculatePackWeight = (shelves) => {
   const packWeight = shelves.reduce((totalWeight, shelf) => {
     const shelfWeight = parseFloat(Object.values(shelf).flat()[0]); 


### PR DESCRIPTION
## What does this PR do (summary of changes)?
- When a shelf was deleted, state was not matching up with the information in the database
- A method was created to update the item list when a shelf was deleted, and then state is updated with the new list of items
- This change was made, because the API response did not provide data, so data had to be manipulated on frontend side to reflect the database
## How should it be tested?
- Add a shelf in the dashboard, you should see the state of items reflecting the added shelf
- Remove the shelf , you should see the state of items reflecting the removed shelf
- State should be matching what is sent to the database
## Future Iterations:
- none at this time
