### PR TITLE
Fix mobile styling bugs on drop down form and add shelf form

### DIFF
--- a/src/components/AddShelfForm/AddShelfForm.js
+++ b/src/components/AddShelfForm/AddShelfForm.js
@@ -34,26 +34,28 @@ class AddShelfForm extends Component {
 
   render() {
     return (
+      <>
+      {this.state.error && <p className="form-add-shelf-error" data-cy="add-shelf-msg">{this.state.error}</p>}
       <form className="form-add-shelf-container" onSubmit={this.handleSubmit} data-cy="add-shelf-form">
         <button 
-        aria-label="add shelf"
-        className="form-add-shelf-btn"
-        type="submit"
-        data-cy="add-shelf-btn"
-        >
-          add a shelf
-      </button>
-      <input
-        aria-label="enter shelf name"
-        className="form-add-shelf-input"
-        type="text"
-        value={this.state.newShelf}
-        name="newShelf"
-        onChange={this.handleChange}
-        data-cy="add-shelf-input"
-      />
-      {this.state.error && <p className="form-add-shelf-error" data-cy="add-shelf-msg">{this.state.error}</p>}
-    </form>
+          aria-label="add shelf"
+          className="form-add-shelf-btn"
+          type="submit"
+          data-cy="add-shelf-btn"
+          >
+            add a shelf
+        </button>
+        <input
+          aria-label="enter shelf name"
+          className="form-add-shelf-input"
+          type="text"
+          value={this.state.newShelf}
+          name="newShelf"
+          onChange={this.handleChange}
+          data-cy="add-shelf-input"
+        />
+      </form>
+    </>
     )
   }
 }

--- a/src/components/AddShelfForm/AddShelfForm.scss
+++ b/src/components/AddShelfForm/AddShelfForm.scss
@@ -5,26 +5,28 @@
 
 .form-add-shelf-btn {
   @include buttonStyle($dark-grey, $lime-green);
-  margin-left: 20px;
+  margin: 20px;
   padding: 5px 10px; 
   font-weight: 600;  
 }
 
 .form-add-shelf-input {
-  margin: 0px 20px;
+  margin: 20px 10px;
   width: 30%;
-  height: 20px;   
+  height: 20px; 
+  border: thin solid $dark-grey;  
 }
 
 .form-add-shelf-error {
   font-weight: 600; 
   text-shadow: 1px 1px 10px rgb(255, 0, 0); 
-  margin: 0px; 
+  margin: 10px; 
 }
 
 @media screen and (max-width: 700px) {
 
   .form-add-shelf-input {
-   width: 70%;   
+   width: 70%;
+   height: 25px;    
   }
 }

--- a/src/components/PackStatistics/PackStatistics.scss
+++ b/src/components/PackStatistics/PackStatistics.scss
@@ -58,7 +58,6 @@
   .statistics-container {
     flex-direction: row;
   }
-
 }
 
 
@@ -67,7 +66,6 @@
   .statistics-container {
     flex-direction: column; 
   }
-
 }
 
 

--- a/src/components/ShelfCard/ShelfCard.js
+++ b/src/components/ShelfCard/ShelfCard.js
@@ -94,7 +94,7 @@ class ShelfCard extends Component {
         </div>
         <div className="shelf-expand-container">
           {this.state.error && <p className="form-error-msg" data-cy="form-error-msg">{this.state.error}</p>}
-          <form className={`form-add-item ${this.state.expanded}`} onSubmit={(event) => this.handleSubmit(event, shelfName)}>
+          <form className={`form-add-item ${this.state.expanded}`} onSubmit={(event) => this. handleSubmit(event, shelfName)}>
             <label className="form-item-label">gear name
             <input
               className="form-item-input"

--- a/src/components/ShelfCard/ShelfCard.scss
+++ b/src/components/ShelfCard/ShelfCard.scss
@@ -59,7 +59,7 @@
   align-items: center; 
   background-color: $dark-grey;
   padding: 10px 0px 10px 30px; 
-  margin-top: -100%;
+  margin-top: -120%;
   transition: all .5s; 
 }
 
@@ -117,7 +117,11 @@
 @media screen and (max-width: 700px) {
 
   .shelf-expand-btn {
-    width: 10%; 
+    width: 50px; 
+  }
+
+  .shelf-remove-category-btn {
+    width: 25px; 
   }
   
   .form-add-item {

--- a/src/components/ShelfItems/ShelfItems.scss
+++ b/src/components/ShelfItems/ShelfItems.scss
@@ -49,11 +49,11 @@
 }
 
 .shelf-item-name {
-  width: 40%; 
+  width: 80%; 
 }
 
 .shelf-item-quantity-container {
-  width: 60%; 
+  width: 90%; 
 }
 
 }


### PR DESCRIPTION
## What does this PR do (summary of changes)?
- This addresses some mobile view styling bugs: 
  - The drop down menu when below 300px was pushing the hidden content outside of the drop down menu
  - The remove shelf button was rendering very tiny and was hard to use
  - the add shelf input's border was being hidden when below 300px wide
  - The add shelf error message was squishing the input too small when in mobile view
## How should it be tested?
- Set the responsive width of the application to 280 and try out all the features, the UX should be operational and there should be no issues with functionality or weird styling issues. 
## Future Iterations:
- none at this time
