### PR TITLE
Fix/flaky load msg test

### DIFF
--- a/cypress/integration/examples/app_spec.js
+++ b/cypress/integration/examples/app_spec.js
@@ -72,10 +72,10 @@ describe("Loading messages", () => {
     cy.get("[data-cy=loading-error-msg]").contains("We can't load your shelves right now, please try again later");
   });
 
-  it("should show a loading message if shelves are loading", () => {
+  it.only("should show a loading message if shelves are loading", () => {
 
-    cy.intercept("https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d", {fixture:"shelves.json"});
-    cy.intercept(`https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d/basket/navigation`, {fixture: "item1.json"});
+    cy.intercept("https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d", {delay: 1000, fixture:"shelves.json"});
+    cy.intercept(`https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d/basket/navigation`, {delay: 1000, fixture: "item1.json"});
     cy.visit("http://localhost:3000/dashboard")
     cy.contains('Loading shelves...');
 

--- a/cypress/integration/examples/app_spec.js
+++ b/cypress/integration/examples/app_spec.js
@@ -205,7 +205,7 @@ describe("Adding a shelf", () => {
 describe("Deleting a shelf", () => {
   beforeEach(() => {
    
-    cy.intercept("DELETE", "https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d/basket/cooking", {fixture: ""})
+    cy.intercept("DELETE", "https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d/basket/cooking", {fixture: ""}).as("deleteShelf")
     cy.intercept(`https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d/basket/navigation`, {fixture: "item1.json"});
     cy.intercept("POST", "https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d/basket/cooking", {fixture: "item3.json"});
     cy.intercept("https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d", {fixture:"shelves.json"})  
@@ -231,11 +231,12 @@ describe("Deleting a shelf", () => {
     cy.get("[data-cy=modal]").should("not.exist"); 
   });
 
-  it.only("Allows a user to delete a shelf after being warned", () => {
+  it("Allows a user to delete a shelf after being warned", () => {
     cy.get("[data-cy=add-shelf-input]").type("cooking");
     cy.get("[data-cy=add-shelf-btn]").click();
     cy.get("[data-cy=remove-category]").eq(0).click();
     cy.get("[data-cy=modal-remove-btn]").click();
+    cy.wait("@deleteShelf")
     cy.get("[data-cy=shelf]").eq(1).should("not.exist"); 
     cy.get("[data-cy=shelves]").should("contain", "navigation")
       .and("not.contain", "cooking"); 

--- a/cypress/integration/examples/app_spec.js
+++ b/cypress/integration/examples/app_spec.js
@@ -72,7 +72,7 @@ describe("Loading messages", () => {
     cy.get("[data-cy=loading-error-msg]").contains("We can't load your shelves right now, please try again later");
   });
 
-  it.only("should show a loading message if shelves are loading", () => {
+  it("should show a loading message if shelves are loading", () => {
 
     cy.intercept("https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d", {delay: 1000, fixture:"shelves.json"});
     cy.intercept(`https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d/basket/navigation`, {delay: 1000, fixture: "item1.json"});
@@ -205,7 +205,7 @@ describe("Adding a shelf", () => {
 describe("Deleting a shelf", () => {
   beforeEach(() => {
    
-    cy.intercept("DELETE", "https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d/basket/cooking", {fixture: ""}).as("deleteItem");
+    cy.intercept("DELETE", "https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d/basket/cooking", {fixture: ""})
     cy.intercept(`https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d/basket/navigation`, {fixture: "item1.json"});
     cy.intercept("POST", "https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d/basket/cooking", {fixture: "item3.json"});
     cy.intercept("https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d", {fixture:"shelves.json"})  
@@ -231,12 +231,11 @@ describe("Deleting a shelf", () => {
     cy.get("[data-cy=modal]").should("not.exist"); 
   });
 
-  it("Allows a user to delete a shelf after being warned", () => {
+  it.only("Allows a user to delete a shelf after being warned", () => {
     cy.get("[data-cy=add-shelf-input]").type("cooking");
     cy.get("[data-cy=add-shelf-btn]").click();
     cy.get("[data-cy=remove-category]").eq(0).click();
     cy.get("[data-cy=modal-remove-btn]").click();
-    cy.wait("@deleteItem");
     cy.get("[data-cy=shelf]").eq(1).should("not.exist"); 
     cy.get("[data-cy=shelves]").should("contain", "navigation")
       .and("not.contain", "cooking"); 

--- a/cypress/integration/examples/app_spec.js
+++ b/cypress/integration/examples/app_spec.js
@@ -206,7 +206,7 @@ describe("Adding a shelf", () => {
 describe("Deleting a shelf", () => {
   beforeEach(() => {
    
-    cy.intercept("DELETE", "https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d/basket/cooking", {fixture: ""}).as("deleteShelf")
+    cy.intercept("DELETE", "https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d/basket/cooking", {fixture: ""})
     cy.intercept(`https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d/basket/navigation`, {fixture: "item1.json"});
     cy.intercept("POST", "https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d/basket/cooking", {fixture: "item3.json"});
     cy.intercept("https://getpantry.cloud/apiv1/pantry/929de230-c666-4f11-9602-b7c818abee8d", {fixture:"shelves.json"})  
@@ -237,7 +237,6 @@ describe("Deleting a shelf", () => {
     cy.get("[data-cy=add-shelf-btn]").click();
     cy.get("[data-cy=remove-category]").eq(0).click();
     cy.get("[data-cy=modal-remove-btn]").click();
-    cy.wait("@deleteShelf")
     cy.get("[data-cy=shelf]").eq(1).should("not.exist"); 
     cy.get("[data-cy=shelves]").should("contain", "navigation")
       .and("not.contain", "cooking"); 

--- a/cypress/integration/examples/app_spec.js
+++ b/cypress/integration/examples/app_spec.js
@@ -98,7 +98,7 @@ describe("Adding an item", () => {
     cy.visit("http://localhost:3000/dashboard");
 
   });
-  it.only("should let a user add items to their shelf and update the dashboard", () => {
+  it("should let a user add items to their shelf and update the dashboard", () => {
     cy.get("[data-cy=expand-shelf-btn]").first().click();
     cy.get("[data-cy=expand-icon]").should("have.class", "expanded"); 
     cy.get("[data-cy=item-name-input]").first().type("pocket rocket stove");

--- a/cypress/integration/examples/app_spec.js
+++ b/cypress/integration/examples/app_spec.js
@@ -98,7 +98,7 @@ describe("Adding an item", () => {
     cy.visit("http://localhost:3000/dashboard");
 
   });
-  it("should let a user add items to their shelf and update the dashboard", () => {
+  it.only("should let a user add items to their shelf and update the dashboard", () => {
     cy.get("[data-cy=expand-shelf-btn]").first().click();
     cy.get("[data-cy=expand-icon]").should("have.class", "expanded"); 
     cy.get("[data-cy=item-name-input]").first().type("pocket rocket stove");
@@ -106,6 +106,7 @@ describe("Adding an item", () => {
     cy.get("[data-cy=item-amount-input]").first().type("1");
     cy.get("[data-cy=item-add-btn]").first().click();
     cy.wait("@addedItem")
+    cy.wait(1000);
     cy.get("[data-cy=added-item]").eq(1).should("contain", "pocket rocket stove")
     .and("contain", "weight: 34.6")
     .and("contain", "amount: 1");

--- a/src/components/ShelfCard/ShelfCard.js
+++ b/src/components/ShelfCard/ShelfCard.js
@@ -94,7 +94,7 @@ class ShelfCard extends Component {
         </div>
         <div className="shelf-expand-container">
           {this.state.error && <p className="form-error-msg" data-cy="form-error-msg">{this.state.error}</p>}
-          <form className={`form-add-item ${this.state.expanded}`} onSubmit={(event) => this. handleSubmit(event, shelfName)}>
+          <form className={`form-add-item ${this.state.expanded}`} onSubmit={(event) => this.handleSubmit(event, shelfName)}>
             <label className="form-item-label">gear name
             <input
               className="form-item-input"


### PR DESCRIPTION
## What does this PR do (summary of changes)?
- The loading message cypress test was flaky and passing/failing on different occasions
- A delay was added to the intercept to make sure the test has time to register the loading message
- An alias was removed from the delete shelf cypress test, this caused the Travis CI build to fail
## How should it be tested?
- all tests should pass locally, and all test should pass on Travis CI
## Future Iterations:
- none at this time
